### PR TITLE
fix: Unicode course data causes errors when sending to ClickHouse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         python-version: ['3.8']
         toxenv: [quality, docs, pii_check, django32, django40]
 

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
 
   push:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/event_sink_clickhouse/__init__.py
+++ b/event_sink_clickhouse/__init__.py
@@ -2,4 +2,4 @@
 A sink for Open edX events to send them to ClickHouse.
 """
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'

--- a/event_sink_clickhouse/sinks/course_published.py
+++ b/event_sink_clickhouse/sinks/course_published.py
@@ -245,7 +245,7 @@ class CoursePublishedSink(BaseSink):
         request = requests.Request(
             'POST',
             self.ch_url,
-            data=output.getvalue(),
+            data=output.getvalue().encode("utf-8"),
             params=params,
             auth=self.ch_auth
         )
@@ -270,7 +270,7 @@ class CoursePublishedSink(BaseSink):
         request = requests.Request(
             'POST',
             self.ch_url,
-            data=output.getvalue(),
+            data=output.getvalue().encode("utf-8"),
             params=params,
             auth=self.ch_auth
         )

--- a/test_utils/helpers.py
+++ b/test_utils/helpers.py
@@ -201,7 +201,7 @@ def check_overview_csv_matcher(course_overview):
     def match(request):
         body = request.body
 
-        f = StringIO(body)
+        f = StringIO(body.decode("utf-8"))
         reader = csv.reader(f)
 
         i = 0
@@ -251,7 +251,7 @@ def check_block_csv_matcher(course):
     that actually does the matching.
     """
     def match(request):
-        body = request.body
+        body = request.body.decode("utf-8")
         lines = body.split("\n")[:-1]
 
         # There should be one CSV line for each block in the test course


### PR DESCRIPTION
**Description:** Fixes unicode errors when sending to ClickHouse by explicitly encoding the CSV output as utf-8. 

**ISSUE:** 
Closes: #22 

**Installation instructions:** In a Tutor Aspects local setup you can:

- Change OPENEDX_EXTRA_PIP_REQUIREMENTS for this package to `"git+https://github.com/openedx/openedx-event-sink-clickhouse.git@bmtcril/fix_unicode",`

**Testing instructions:**

After installing from this branch:

- Rebuild the openedx image: `tutor images build openedx`
- `tutor local start -d`
- Create some unicode in your course name, problem / video block names, etc.
- Publish the course
- Browse the course, watch the video or try the problem
- Confirm in the cms-worker logs that there are no errors
- Confirm in ClickHouse that the changes appear correctly in the `event_sink.course_overviews` / `event_sink.course_blocks` tables (note that a lot of database tools don't handle utf-8 well, if there are "weird characters" in the output you can assume this passes and go to the next step)
- Check Superset to make sure that the UTF-8 characters show up correctly in the reports and filters
