### PR TITLE
feat: add graded boolean to xblock json (FC-0033)

### DIFF
--- a/event_sink_clickhouse/__init__.py
+++ b/event_sink_clickhouse/__init__.py
@@ -2,4 +2,4 @@
 A sink for Open edX events to send them to ClickHouse.
 """
 
-__version__ = '0.1.1'
+__version__ = '0.1.2'

--- a/event_sink_clickhouse/sinks/course_published.py
+++ b/event_sink_clickhouse/sinks/course_published.py
@@ -106,6 +106,7 @@ class CoursePublishedSink(BaseSink):
             'run': course_key.run,
             'block_type': block_type,
             'detached': 1 if block_type in detached_xblock_types else 0,
+            'graded': 1 if getattr(item, 'graded', False) else 0,
         }
 
         # Core table data, if things change here it's a big deal.

--- a/test_utils/helpers.py
+++ b/test_utils/helpers.py
@@ -52,7 +52,7 @@ class FakeXBlock:
     """
     Fakes the parameters of an XBlock that we care about.
     """
-    def __init__(self, identifier, detached_block=False):
+    def __init__(self, identifier, detached_block=False, graded=False):
         self.block_type = "course_info" if detached_block else "vertical"
         self.scope_ids = Mock()
         self.scope_ids.usage_id.course_key = course_key_factory()
@@ -61,6 +61,7 @@ class FakeXBlock:
         self.display_name_with_default = f"Display name {identifier}"
         self.edited_on = datetime.now()
         self.children = []
+        self.graded = graded
 
     def get_children(self):
         """
@@ -187,6 +188,10 @@ def course_factory():
     # Create some detached blocks at the top level
     for i in range(3):
         course.append(FakeXBlock(f"Detached {i}", detached_block=True))
+
+    # Create some graded blocks at the top level
+    for i in range(3):
+        course.append(FakeXBlock(f"Graded {i}", graded=True))
 
     return course
 

--- a/tests/test_course_published.py
+++ b/tests/test_course_published.py
@@ -1,7 +1,9 @@
 """
 Tests for the course_published sinks.
 """
+import json
 import logging
+import uuid
 from datetime import datetime
 from unittest.mock import patch
 
@@ -206,3 +208,18 @@ def test_get_last_dump_time():
     last_published_date = sink.get_course_last_dump_time(course_key)
     dt = datetime.strptime(last_published_date, "%Y-%m-%d %H:%M:%S.%f+00:00")
     assert dt
+
+
+def test_xblock_json_seralization():
+    course = course_factory()
+
+    for index, item in enumerate(course):
+        block = CoursePublishedSink.serialize_xblock(
+            item,
+            index,
+            mock_detached_xblock_types(),
+            str(uuid.uuid4()),
+            str(datetime.now()),
+        )
+        block_json = json.loads(block['xblock_data_json'])
+        assert bool(int(block_json['graded'])) == item.graded


### PR DESCRIPTION
**Description:** This PR adds an items `graded` attribute to the `xblock_data_json` field and defaults to false if that attribute doesn't exist. This attribute indicates whether the xblock is part of a graded subsection and is a relevant piece of metadata for course problems.

This was discussed in [tutor-contrib-aspects issue #292](https://github.com/openedx/tutor-contrib-aspects/issues/292)

**Testing instructions:**

1. Install this branch as part of `tutor-contrib-aspects`
2. Rebuild images via `tutor images build openedx --no-cache`
3. Run `tutor local do dump-courses-to-clickhouse` (possibly with `--options "--force"` if no courses are pushed)
4. There should now be a `graded` attribute for some blocks in the `xblock_json_data` field in `event_sink.course_blocks`
5. If necessary, generate event data by running the LMS locally and clicking through a course page.

**Reviewers:**
- [ ] tag reviewer
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)
