### PR TITLE
fix: omit transform of ids for event sink

### DIFF
--- a/event_sink_clickhouse/__init__.py
+++ b/event_sink_clickhouse/__init__.py
@@ -2,4 +2,4 @@
 A sink for Open edX events to send them to ClickHouse.
 """
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/event_sink_clickhouse/sinks/base_sink.py
+++ b/event_sink_clickhouse/sinks/base_sink.py
@@ -297,14 +297,14 @@ class ModelBaseSink(BaseSink):
         if ids:
             item_keys = [self.convert_id(item_id) for item_id in ids]
         else:
-            item_keys = [self.convert_id(item.id) for item in self.get_queryset()]
+            item_keys = [item.id for item in self.get_queryset()]
 
         skip_ids = (
-            [self.convert_id(item_id) for item_id in skip_ids] if skip_ids else []
+            [str(item_id) for item_id in skip_ids] if skip_ids else []
         )
 
         for item_key in item_keys:
-            if item_key in skip_ids:
+            if str(item_key) in skip_ids:
                 yield item_key, False, f"{self.name} is explicitly skipped"
             elif force_dump:
                 yield item_key, True, "Force is set"


### PR DESCRIPTION
**Description:** This PR fixes #37 

The issue was that the CourseKey object was compared vs. a course-id string, which represented the same, but was not equal to Python. This PR updated that comparison casting everything to string

**ISSUE:** #37

**Testing instructions:**

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
