### PR TITLE
Add tree location and completion_mode to XBlock serialization

### DIFF
--- a/event_sink_clickhouse/__init__.py
+++ b/event_sink_clickhouse/__init__.py
@@ -2,4 +2,4 @@
 A sink for Open edX events to send them to ClickHouse.
 """
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/event_sink_clickhouse/serializers.py
+++ b/event_sink_clickhouse/serializers.py
@@ -127,7 +127,6 @@ class CourseOverviewSerializer(BaseSinkSerializer, serializers.ModelSerializer):
             "entrance_exam_enabled": getattr(overview, "entrance_exam_enabled", ""),
             "external_id": getattr(overview, "external_id", ""),
             "language": getattr(overview, "language", ""),
-            "course_tree_location": getattr(overview, "language", "{}"),
         }
         return json.dumps(json_fields)
 

--- a/event_sink_clickhouse/serializers.py
+++ b/event_sink_clickhouse/serializers.py
@@ -127,6 +127,7 @@ class CourseOverviewSerializer(BaseSinkSerializer, serializers.ModelSerializer):
             "entrance_exam_enabled": getattr(overview, "entrance_exam_enabled", ""),
             "external_id": getattr(overview, "external_id", ""),
             "language": getattr(overview, "language", ""),
+            "course_tree_location": getattr(overview, "language", "{}"),
         }
         return json.dumps(json_fields)
 

--- a/event_sink_clickhouse/sinks/course_published.py
+++ b/event_sink_clickhouse/sinks/course_published.py
@@ -69,7 +69,6 @@ class XBlockSink(ModelBaseSink):
         """
         Serialize an XBlock into a dict
         """
-        print(item)
         course_key = CourseKey.from_string(item["course_key"])
         modulestore = get_modulestore()
         detached_xblock_types = get_detached_xblock_types()
@@ -94,8 +93,6 @@ class XBlockSink(ModelBaseSink):
                 initial["time_last_dumped"],
             )
 
-            print(fields["xblock_data_json"]["block_type"])
-
             if fields["xblock_data_json"]["block_type"] == "chapter":
                 section_idx += 1
                 subsection_idx = 0
@@ -106,11 +103,9 @@ class XBlockSink(ModelBaseSink):
             elif fields["xblock_data_json"]["block_type"] == "vertical":
                 unit_idx += 1
 
-            fields["xblock_data_json"]["course_tree_location"] = {
-                "section": section_idx,
-                "subsection": subsection_idx,
-                "unit": unit_idx
-            }
+            fields["xblock_data_json"]["section"] = section_idx
+            fields["xblock_data_json"]["subsection"] = subsection_idx
+            fields["xblock_data_json"]["unit"] = unit_idx
 
             fields["xblock_data_json"] = json.dumps(fields["xblock_data_json"])
             location_to_node[
@@ -172,6 +167,7 @@ class XBlockSink(ModelBaseSink):
             "block_type": block_type,
             "detached": 1 if block_type in detached_xblock_types else 0,
             "graded": 1 if getattr(item, "graded", False) else 0,
+            "completion_mode": getattr(item, "completion_mode", ""),
         }
 
         # Core table data, if things change here it's a big deal.

--- a/test_utils/helpers.py
+++ b/test_utils/helpers.py
@@ -52,7 +52,7 @@ class FakeXBlock:
     """
     Fakes the parameters of an XBlock that we care about.
     """
-    def __init__(self, identifier, block_type="vertical", graded=False):
+    def __init__(self, identifier, block_type="vertical", graded=False, completion_mode="unknown"):
         self.block_type = block_type
         self.scope_ids = Mock()
         self.scope_ids.usage_id.course_key = course_key_factory()
@@ -62,6 +62,7 @@ class FakeXBlock:
         self.edited_on = datetime.now()
         self.children = []
         self.graded = graded
+        self.completion_mode = completion_mode
 
     def get_children(self):
         """
@@ -233,6 +234,11 @@ def course_factory():
     # Create some graded blocks at the top level
     for i in range(3):
         course.append(FakeXBlock(f"Graded {i}", graded=True))
+
+    # Create some completable blocks at the top level
+    course.append(FakeXBlock("Completable", completion_mode="completable"))
+    course.append(FakeXBlock("Aggregator", completion_mode="aggregator"))
+    course.append(FakeXBlock("Excluded", completion_mode="excluded"))
 
     return course
 


### PR DESCRIPTION
**Description:** 
Adds new fields to the JSON attribute of serialized XBlocks:
- An indication of where in the course tree a block lives (section / subsection / unit)
- What the block's completion_mode is

The first is for performance and consistency reasons, we don't to compute this in SQL while a dump is occurring, for instance. The second is so we can calculate which blocks are "completable" but have not yet been completed, for instance on new courses.
