### PR TITLE
build: tag this in future Open edX releases

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -13,11 +13,3 @@ oeps:
     oep-18: true
     oep-30:
         state: true
-openedx-release:
-    # The openedx-release key is described in OEP-10:
-    #   https://open-edx-proposals.readthedocs.io/en/latest/oep-0010-proc-openedx-releases.html
-    # The FAQ might also be helpful: https://openedx.atlassian.net/wiki/spaces/COMM/pages/1331268879/Open+edX+Release+FAQ
-    # Note: This will only work if the repo is in the `openedx` org in github.  Repos in other orgs that have this
-    # setting will still be treated as if they don't want to be part of the Open edX releases.
-    maybe: true   # Delete this "maybe" line when you have decided about Open edX inclusion.
-    ref: main

--- a/openedx.yaml
+++ b/openedx.yaml
@@ -13,3 +13,8 @@ oeps:
     oep-18: true
     oep-30:
         state: true
+openedx-release:
+    # The openedx-release key is described in OEP-10:
+    #   https://open-edx-proposals.readthedocs.io/en/latest/oep-0010-proc-openedx-releases.html
+    # The FAQ might also be helpful: https://openedx.atlassian.net/wiki/spaces/COMM/pages/1331268879/Open+edX+Release+FAQ
+    ref: main


### PR DESCRIPTION
~build: don't tag this in the named release~

~@bmtcril , @cmltaWt0 mentioned that we shouldn't tag this in the release. Is that because it's installed via pip requirements?~

UPDATE: 

build: tag this in future Open edX releases

...because it's an optional plugin that will eventually be used by
the open source community.