### PR TITLE
Adds user retirement sink

### DIFF
--- a/event_sink_clickhouse/__init__.py
+++ b/event_sink_clickhouse/__init__.py
@@ -2,4 +2,4 @@
 A sink for Open edX events to send them to ClickHouse.
 """
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/event_sink_clickhouse/serializers.py
+++ b/event_sink_clickhouse/serializers.py
@@ -82,6 +82,20 @@ class UserExternalIDSerializer(BaseSinkSerializer, serializers.ModelSerializer):
         ]
 
 
+class UserRetirementSerializer(BaseSinkSerializer, serializers.ModelSerializer):
+    """Serializer for user retirement events."""
+
+    user_id = serializers.CharField(source="id")
+
+    class Meta:
+        """Meta class for user retirement serializer."""
+
+        model = get_model("auth_user")
+        fields = [
+            "user_id",
+        ]
+
+
 class CourseOverviewSerializer(BaseSinkSerializer, serializers.ModelSerializer):
     """Serializer for course overview events."""
 

--- a/event_sink_clickhouse/settings/common.py
+++ b/event_sink_clickhouse/settings/common.py
@@ -19,6 +19,10 @@ def plugin_settings(settings):
     }
 
     settings.EVENT_SINK_CLICKHOUSE_MODEL_CONFIG = {
+        "auth_user": {
+            "module": "django.contrib.auth.models",
+            "model": "User",
+        },
         "user_profile": {
             "module": "common.djangoapps.student.models",
             "model": "UserProfile",

--- a/event_sink_clickhouse/settings/common.py
+++ b/event_sink_clickhouse/settings/common.py
@@ -18,6 +18,11 @@ def plugin_settings(settings):
         "timeout_secs": 5,
     }
 
+    settings.EVENT_SINK_CLICKHOUSE_PII_MODELS = [
+        "user_profile",
+        "external_id",
+    ]
+
     settings.EVENT_SINK_CLICKHOUSE_MODEL_CONFIG = {
         "auth_user": {
             "module": "django.contrib.auth.models",

--- a/event_sink_clickhouse/settings/production.py
+++ b/event_sink_clickhouse/settings/production.py
@@ -11,3 +11,7 @@ def plugin_settings(settings):
         "EVENT_SINK_CLICKHOUSE_BACKEND_CONFIG",
         settings.EVENT_SINK_CLICKHOUSE_BACKEND_CONFIG,
     )
+    settings.EVENT_SINK_CLICKHOUSE_PII_MODELS = settings.ENV_TOKENS.get(
+        "EVENT_SINK_CLICKHOUSE_PII_MODELS",
+        settings.EVENT_SINK_CLICKHOUSE_PII_MODELS,
+    )

--- a/event_sink_clickhouse/signals.py
+++ b/event_sink_clickhouse/signals.py
@@ -2,10 +2,17 @@
 Signal handler functions, mapped to specific signals in apps.py.
 """
 from django.db.models.signals import post_save
-from django.dispatch import receiver
+from django.dispatch import Signal, receiver
 
 from event_sink_clickhouse.sinks.external_id_sink import ExternalIdSink
+from event_sink_clickhouse.sinks.user_retire import UserRetirementSink
 from event_sink_clickhouse.utils import get_model
+
+try:
+    from openedx.core.djangoapps.user_api.accounts.signals import USER_RETIRE_LMS_MISC
+except ImportError:
+    # Tests don't have the platform installed
+    USER_RETIRE_LMS_MISC = Signal()
 
 
 def receive_course_publish(  # pylint: disable=unused-argument  # pragma: no cover
@@ -48,4 +55,22 @@ def on_externalid_saved(  # pylint: disable=unused-argument  # pragma: no cover
         sink_module=sink.__module__,
         sink_name=sink.__class__.__name__,
         object_id=str(instance.id),
+    )
+
+
+@receiver(USER_RETIRE_LMS_MISC)
+def on_user_retirement(  # pylint: disable=unused-argument  # pragma: no cover
+    sender, user, **kwargs
+):
+    """
+    Receives a user retirement signal and queues the retire_user job.
+    """
+    # import here, because signal is registered at startup, but items in tasks are not yet able to be loaded
+    from event_sink_clickhouse.tasks import dump_data_to_clickhouse  # pylint: disable=import-outside-toplevel
+
+    sink = UserRetirementSink(None, None)
+    dump_data_to_clickhouse.delay(
+        sink_module=sink.__module__,
+        sink_name=sink.__class__.__name__,
+        object_id=str(user.id),
     )

--- a/event_sink_clickhouse/signals.py
+++ b/event_sink_clickhouse/signals.py
@@ -4,7 +4,7 @@ Signal handler functions, mapped to specific signals in apps.py.
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
-from event_sink_clickhouse.sinks.external_id_sink import ExternalIDSInk
+from event_sink_clickhouse.sinks.external_id_sink import ExternalIdSink
 from event_sink_clickhouse.utils import get_model
 
 
@@ -43,7 +43,7 @@ def on_externalid_saved(  # pylint: disable=unused-argument  # pragma: no cover
     # import here, because signal is registered at startup, but items in tasks are not yet able to be loaded
     from event_sink_clickhouse.tasks import dump_data_to_clickhouse  # pylint: disable=import-outside-toplevel
 
-    sink = ExternalIDSInk(None, None)
+    sink = ExternalIdSink(None, None)
     dump_data_to_clickhouse.delay(
         sink_module=sink.__module__,
         sink_name=sink.__class__.__name__,

--- a/event_sink_clickhouse/sinks/external_id_sink.py
+++ b/event_sink_clickhouse/sinks/external_id_sink.py
@@ -3,7 +3,7 @@ from event_sink_clickhouse.serializers import UserExternalIDSerializer
 from event_sink_clickhouse.sinks.base_sink import ModelBaseSink
 
 
-class ExternalIDSInk(ModelBaseSink):  # pylint: disable=abstract-method
+class ExternalIdSink(ModelBaseSink):  # pylint: disable=abstract-method
     """
     Sink for user external ID serializer
     """

--- a/event_sink_clickhouse/sinks/user_retire.py
+++ b/event_sink_clickhouse/sinks/user_retire.py
@@ -26,9 +26,12 @@ class UserRetirementSink(ModelBaseSink):  # pylint: disable=abstract-method
 
         Send delete queries to remove the serialized User from ClickHouse.
         """
-        users = serialized_item if many else [serialized_item]
+        if many:
+            users = serialized_item
+        else:
+            users = [serialized_item]
         user_ids = {str(user["user_id"]) for user in users}
-        user_ids_str = ",".join(user_ids)
+        user_ids_str = ",".join(sorted(user_ids))
         clickhouse_pii_tables = getattr(
             settings, "EVENT_SINK_CLICKHOUSE_PII_MODELS", []
         )

--- a/event_sink_clickhouse/sinks/user_retire.py
+++ b/event_sink_clickhouse/sinks/user_retire.py
@@ -1,0 +1,43 @@
+"""User retirement sink"""
+import requests
+
+from event_sink_clickhouse.serializers import UserRetirementSerializer
+from event_sink_clickhouse.sinks.base_sink import ModelBaseSink
+
+
+class UserRetirementSink(ModelBaseSink):  # pylint: disable=abstract-method
+    """
+    Sink for user retirement events
+    """
+
+    model = "auth_user"
+    unique_key = "id"
+    clickhouse_table_name = ["user_profile", "external_id"]
+    timestamp_field = "modified"
+    name = "User Retirement"
+    serializer_class = UserRetirementSerializer
+
+    def send_item(self, serialized_item, many=False):
+        """
+        Unlike the other data sinks, the User Retirement sink deletes records from the user PII tables in Clickhouse.
+
+        Send delete queries to remove the serialized User from ClickHouse.
+        """
+        users = serialized_item if many else [serialized_item]
+        user_ids = {str(user["user_id"]) for user in users}
+        user_ids_str = ",".join(user_ids)
+
+        for table in self.clickhouse_table_name:
+            params = {
+                "query": f"ALTER TABLE {self.ch_database}.{table} DELETE WHERE user_id in ({user_ids_str})",
+            }
+            request = requests.Request(
+                "POST",
+                self.ch_url,
+                params=params,
+                auth=self.ch_auth,
+            )
+            self._send_clickhouse_request(
+                request,
+                expected_insert_rows=0,  # DELETE requests don't return a row count
+            )

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -7,3 +7,4 @@
 
 diff-cover                # Changeset diff test coverage
 edx-i18n-tools            # For i18n_tool dummy
+black                     # For formatting

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -27,6 +27,8 @@ billiard==4.2.0
     # via
     #   -r requirements/quality.txt
     #   celery
+black==23.11.0
+    # via -r requirements/dev.in
 build==1.0.3
     # via
     #   -r requirements/pip-tools.txt
@@ -58,6 +60,7 @@ click==8.1.7
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
+    #   black
     #   celery
     #   click-didyoumean
     #   click-log
@@ -191,6 +194,8 @@ mccabe==0.7.0
     # via
     #   -r requirements/quality.txt
     #   pylint
+mypy-extensions==1.0.0
+    # via black
 newrelic==9.2.0
     # via
     #   -r requirements/quality.txt
@@ -200,12 +205,15 @@ packaging==23.2
     #   -r requirements/ci.txt
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
+    #   black
     #   build
     #   pyproject-api
     #   pytest
     #   tox
 path==16.7.1
     # via edx-i18n-tools
+pathspec==0.11.2
+    # via black
 pbr==6.0.0
     # via
     #   -r requirements/quality.txt
@@ -217,6 +225,7 @@ platformdirs==3.11.0
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
+    #   black
     #   pylint
     #   tox
     #   virtualenv
@@ -345,6 +354,7 @@ tomli==2.0.1
     #   -r requirements/ci.txt
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
+    #   black
     #   build
     #   coverage
     #   pip-tools

--- a/test_utils/helpers.py
+++ b/test_utils/helpers.py
@@ -47,6 +47,8 @@ FakeCourseOverview = namedtuple("FakeCourseOverview", [
     "language",
 ])
 
+FakeUser = namedtuple("FakeUser", ["id"])
+
 
 class FakeXBlock:
     """

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, patch
 from django.test import TestCase
 
 from event_sink_clickhouse.signals import on_externalid_saved, on_user_profile_updated, receive_course_publish
-from event_sink_clickhouse.sinks.external_id_sink import ExternalIDSInk
+from event_sink_clickhouse.sinks.external_id_sink import ExternalIdSink
 
 
 class SignalHandlersTestCase(TestCase):
@@ -45,7 +45,7 @@ class SignalHandlersTestCase(TestCase):
         sender = Mock()
         on_externalid_saved(sender, instance)
 
-        sink = ExternalIDSInk(None, None)
+        sink = ExternalIdSink(None, None)
 
         mock_dump_task.delay.assert_called_once_with(
             sink_module=sink.__module__,

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -5,8 +5,14 @@ from unittest.mock import Mock, patch
 
 from django.test import TestCase
 
-from event_sink_clickhouse.signals import on_externalid_saved, on_user_profile_updated, receive_course_publish
+from event_sink_clickhouse.signals import (
+    on_externalid_saved,
+    on_user_profile_updated,
+    on_user_retirement,
+    receive_course_publish,
+)
 from event_sink_clickhouse.sinks.external_id_sink import ExternalIdSink
+from event_sink_clickhouse.sinks.user_retire import UserRetirementSink
 
 
 class SignalHandlersTestCase(TestCase):
@@ -46,6 +52,23 @@ class SignalHandlersTestCase(TestCase):
         on_externalid_saved(sender, instance)
 
         sink = ExternalIdSink(None, None)
+
+        mock_dump_task.delay.assert_called_once_with(
+            sink_module=sink.__module__,
+            sink_name=sink.__class__.__name__,
+            object_id=str(instance.id),
+        )
+
+    @patch("event_sink_clickhouse.tasks.dump_data_to_clickhouse")
+    def test_on_user_retirement(self, mock_dump_task):
+        """
+        Test that on_user_retirement calls dump_data_to_clickhouse
+        """
+        instance = Mock()
+        sender = Mock()
+        on_user_retirement(sender, instance)
+
+        sink = UserRetirementSink(None, None)
 
         mock_dump_task.delay.assert_called_once_with(
             sink_module=sink.__module__,

--- a/tests/test_user_retire.py
+++ b/tests/test_user_retire.py
@@ -1,0 +1,64 @@
+"""
+Tests for the user_retire sinks.
+"""
+from unittest.mock import patch
+
+import responses
+from responses.registries import OrderedRegistry
+
+from event_sink_clickhouse.sinks.user_retire import UserRetirementSink
+from event_sink_clickhouse.tasks import dump_data_to_clickhouse
+from test_utils.helpers import FakeUser
+
+
+@responses.activate(  # pylint: disable=unexpected-keyword-arg,no-value-for-parameter
+    registry=OrderedRegistry
+)
+@patch("event_sink_clickhouse.sinks.user_retire.UserRetirementSink.serialize_item")
+@patch("event_sink_clickhouse.sinks.user_retire.UserRetirementSink.is_enabled")
+@patch("event_sink_clickhouse.sinks.user_retire.UserRetirementSink.get_model")
+def test_retire_user(mock_user_model, mock_is_enabled, mock_serialize_item):
+    """
+    Test of a successful user retirement.
+    """
+    # Create a fake user
+    user = FakeUser(246)
+    mock_user_model.return_value.get_from_id.return_value = user
+    mock_is_enabled.return_value = True
+    mock_serialize_item.return_value = {"user_id": user.id}
+
+    # Use the responses library to catch the POSTs to ClickHouse
+    # and match them against the expected values
+    user_profile_delete = responses.post(
+        "https://foo.bar/",
+        match=[
+            responses.matchers.query_param_matcher(
+                {
+                    "query": f"ALTER TABLE cool_data.user_profile DELETE WHERE user_id in ({user.id})",
+                }
+            )
+        ],
+    )
+    external_id_delete = responses.post(
+        "https://foo.bar/",
+        match=[
+            responses.matchers.query_param_matcher(
+                {
+                    "query": f"ALTER TABLE cool_data.external_id DELETE WHERE user_id in ({user.id})",
+                }
+            )
+        ],
+    )
+
+    sink = UserRetirementSink(None, None)
+    dump_data_to_clickhouse(
+        sink_module=sink.__module__,
+        sink_name=sink.__class__.__name__,
+        object_id=user.id,
+    )
+
+    assert mock_user_model.call_count == 1
+    assert mock_is_enabled.call_count == 1
+    assert mock_serialize_item.call_count == 1
+    assert user_profile_delete.call_count == 1
+    assert external_id_delete.call_count == 1

--- a/tests/test_user_retire.py
+++ b/tests/test_user_retire.py
@@ -4,6 +4,7 @@ Tests for the user_retire sinks.
 from unittest.mock import patch
 
 import responses
+from django.test.utils import override_settings
 from responses.registries import OrderedRegistry
 
 from event_sink_clickhouse.sinks.user_retire import UserRetirementSink
@@ -14,6 +15,7 @@ from test_utils.helpers import FakeUser
 @responses.activate(  # pylint: disable=unexpected-keyword-arg,no-value-for-parameter
     registry=OrderedRegistry
 )
+@override_settings(EVENT_SINK_CLICKHOUSE_PII_MODELS=["user_profile", "external_id"])
 @patch("event_sink_clickhouse.sinks.user_retire.UserRetirementSink.serialize_item")
 @patch("event_sink_clickhouse.sinks.user_retire.UserRetirementSink.is_enabled")
 @patch("event_sink_clickhouse.sinks.user_retire.UserRetirementSink.get_model")


### PR DESCRIPTION
**Description:**

Adds an event sink for "user retirement" events.

On receipt of a `USER_RETIRE_LMS_MISC` Django signal for a given user, the sink will delete all records from the PII tables for that user, currently:

* event_sink.user_profile
* event_sink.external_id

**ISSUE:** https://github.com/openedx/tutor-contrib-aspects/issues/449

**Relates to:** https://github.com/openedx/tutor-contrib-aspects/pull/529

This PR should be merged/tagged first.

**Merge deadline:** none

**Installation instructions:**

To install this temporary branch on your local Tutor Aspects stack:

1. Install the Aspects plugin from https://github.com/openedx/tutor-contrib-aspects/pull/529
1. Install the user retirement plugin, following instructions on https://github.com/hastexo/tutor-contrib-retirement
1. Add this repo/branch to the LMS requirements:
   `echo "git+https://github.com/openedx/openedx-event-sink-clickhouse.git@jill/retire-user#egg=openedx-event-sink-clickhouse==0.5.0" >> "$(tutor config printroot)/env/build/openedx/requirements/private.txt"`
1. Enable Aspects PII:
   `tutor config save -s ASPECTS_ENABLE_PII=True`
1. (optional) Shorten the lifetime of the user_pii dict to 10s to make testing data changes easier:
   `tutor config save -s ASPECTS_PII_CACHE_LIFETIME=10`
1. (optional) Remove the cooling off period to make it easier to process user retirements:
   `tutor config save -s RETIREMENT_COOL_OFF_DAYS=0`
1. Rebuild image:
   `tutor images build openedx --no-cache`
1. Re-init Aspects to use updated settings:
   `tutor local do init -l aspects`
1. Reboot Tutor to use new images:
   `tutor local reboot -d`

**Testing instructions:**

1. Register a new user on the platform, and update that user's Account (aka user profile) details.
    Use Superset's SQL Lab to check that the user profile change(s) flow through to the `event_sink.user_pii` table.
1. Enrol the user in a course to see external IDs created and flowing into the `event_sink.user_pii` table.
1. In the LMS Accounts page, delete the user.
1. From the command line, run the user retirement pipeline to move the user's retirement request from PENDING into COMPLETED.
    `tutor local retire-users`
1. After ASPECTS_PII_CACHE_LIFETIME elapses, check Superset SQL Lab to ensure that the user records have been deleted from `event_sink.user_pii`.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)