### PR TITLE
chore: Update catalog-info owner and arch-interest-groups

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -11,11 +11,11 @@ metadata:
     # We use it in Open edX repos to have a comma-separated list of GitHub user
     # names that might be interested in changes to the architecture of this
     # component.
-    openedx.org/arch-interest-groups: ""
+    openedx.org/arch-interest-groups: "group:openedx-event-sink-clickhouse-maintainers,"
 spec:
 
   # (Required) This can be a group(`group:<group_name>` or a user(`user:<github_username>`)
-  owner: "group:openedx-event-sink-clickhouse-maintainers"
+  owner: "bmtcril"
 
   # (Required) Acceptable Type Values: service, website, library
   type: 'library'


### PR DESCRIPTION
Updating the catalog-info.yaml to change owner to myself and add the maintainers group to arch-interest-groups.